### PR TITLE
Don't complain about unknown cti

### DIFF
--- a/wb_common.v
+++ b/wb_common.v
@@ -33,6 +33,7 @@ function wb_is_last;
 	CTI_CONST_BURST  : wb_is_last = 1'b0;
 	CTI_INC_BURST    : wb_is_last = 1'b0;
 	CTI_END_OF_BURST : wb_is_last = 1'b1;
+	3'bxxx           : wb_is_last = 1'bx;
 	default : $display("%d : Illegal Wishbone B3 cycle type (%b)", $time, cti);
       endcase
    end


### PR DESCRIPTION
When starting [mor1kx-generic](https://github.com/stffrdhrn/mor1kx-generic.git), you always get a warning
```
                   0 : Illegal Wishbone B3 cycle type (xxx)
```
at the very beginning.  This is a bit unnerving (especially since there is no indication whether this is a fatal error or just a warning), and not really accurate anyway; if all bits of `cti` are unknown, then there is no way of knowing that it is illegal either.

This PR removes the warning from `wb_is_last`when `cti` is completely unknown, and just gives a return value of "unknown" instead.